### PR TITLE
remove AUR migration note

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,9 @@
 <h3>Installation</h3>
 
 <b>Arch Linux package</b><br />
-<p>Please note: Starting from June 8th 2015, the Arch User Repository is being migrated to a Git-based platform. Due to that, kdbx-viewer must be obtained from <a href="https://aur4.archlinux.org">https://aur4.archlinux.org</a> at the moment. This will end at August 8th 2015 when the migration is complete. More information can be found <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository#AUR_4">in the Arch wiki</a>.</p>
 <p>There is an Arch Linux AUR package: <b><code><a href="https://aur4.archlinux.org/packages/kdbx-viewer/">kdbx-viewer</a></code></b>. You can install it by either</p>
 <ul>
-  <li>using an AUR package manager, e.g. Yaourt: <code>yaourt -S kdbx-viewer --aur-url https://aur4.archlinux.org</code></li>
+  <li>using an AUR package manager, e.g. Yaourt: <code>yaourt -S kdbx-viewer</code></li>
   <li>building the package, following the instructions on <a href="https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages">installing AUR packages</a> in the Arch wiki.
 </ul>
 


### PR DESCRIPTION
As of August 8th, 2015, the AUR is completely migrated to version 4. This removes the note in the installation information.
